### PR TITLE
OLD Have an explicit extension for E2E extension protection

### DIFF
--- a/double/draft-ietf-perc-double.md
+++ b/double/draft-ietf-perc-double.md
@@ -265,7 +265,6 @@ extension.
 
 # RTP Operations
 
-
 ## Encrypting a Packet
 
 To encrypt a packet, the endpoint encrypts the packet using the inner
@@ -275,17 +274,21 @@ context.  The processes is as follows:
 * Form an RTP packet.  If there are any header extensions, they MUST
   use [@!RFC5285].
 
-* If any extensions are to be protected by the inner transform, insert an E2EEEL
-  extension at the beginning.
+* Apply the inner cryptographic transform to the RTP packet.  If
+  encrypting RTP header extensions end-to-end, then [@!RFC6904] MUST
+  be used when encrypting the RTP packet using the inner cryptographic
+  context.
 
-* Insert an OHB extension after the end-to-end protected extensions.  This OHB
-  MUST replicate the information found in the RTP header.
+* If the endpoint wishes to insert header extensions that can be
+  modified by an Media Distributor, it MUST insert an OHB header
+  extension at the end of any header extensions protected end-to-end
+  (if any), then add any Media Distributor-modifiable header
+  extensions.  In other cases, the endpoint SHOULD still insert an OHB
+  header extension. The OHB MUST replicate the information found in the RTP
+  header following the application of the inner cryptographic
+  transform.  If not already set, the endpoint MUST set the X bit in
+  the RTP header to 1 when introducing the OHB extension.
 
-* Apply the inner cryptographic transform to the RTP packet.  If encrypting RTP
-  header extensions end-to-end, then [@!RFC6904] MUST be used when encrypting
-  the RTP packet using the inner cryptographic context.  Extensions that are
-  not protected end-to-end are not included in the AAD for this transform.
-  
 * Apply the outer cryptographic transform to the RTP packet.  If
   encrypting RTP header extensions hop-by-hop, then [@!RFC6904] MUST
   be used when encrypting the RTP packet using the outer cryptographic

--- a/double/draft-ietf-perc-double.md
+++ b/double/draft-ietf-perc-double.md
@@ -272,7 +272,6 @@ OHB.  To properly preserve original RTP header values, a Media
 Distributor MUST NOT change a value already present in the OHB
 extension.
 
-
 # RTP Operations
 
 ## Additional Authenticated Data

--- a/double/draft-ietf-perc-double.md
+++ b/double/draft-ietf-perc-double.md
@@ -204,10 +204,10 @@ value.  In this case, the OHB has this form:
 
 {align="left"}
 ~~~~~
- 0               
- 0 1 2 3 4 5 6 7 
+ 0                   1
+ 0 1 2 3 4 5 6 7 8 9 0 1 2 3 4 5
 +-+-+-+-+-+-+-+-+---------------+
-|  ID   | len=0 |A|     PT      |
+|  ID   | len=0 |R|     PT      |
 +-+-+-+-+-+-+-+-+---------------+
 ~~~~~
 
@@ -315,7 +315,7 @@ context.  The processes is as follows:
   encrypting RTP header extensions end-to-end, then [@!RFC6904] MUST
   be used when encrypting the RTP packet using the inner cryptographic
   context.
-
+  
 * If the endpoint wishes to insert header extensions that can be
   modified by an Media Distributor, it MUST insert an OHB header
   extension at the end of any header extensions protected end-to-end


### PR DESCRIPTION
As I was [implementing -double in libsrtp](https://github.com/cisco/libsrtp/pull/311), I noticed that the idea of signaling the end of E2E extensions by placement of the OHB is not workable within the current `libsrtp` API because the SRTP layer doesn't know what extension ID corresponds to the OHB.  To fix this issue, this PR proposes adding a second extension that explicitly specifies the length of the E2E extensions.  (Then the OHB MUST be the first thing after the E2E extensions.)

This PR also includes some clarifications as to how the AAD for the inner transform (i.e., the original header and extensions) are reconstructed.