### PR TITLE
Require independent keys between decryption and re-encryption

### DIFF
--- a/double/draft-ietf-perc-double.md
+++ b/double/draft-ietf-perc-double.md
@@ -323,6 +323,13 @@ before transmitting.
   Sequence Number. If encrypting RTP header extensions hop-by-hop,
   then [@!RFC6904] MUST be used.
 
+The Media Distributor that decrypts, modifies, and re-encrypts
+packets in this way MUST use an independent key and salt for each
+recipient, and MUST NOT re-encrypt the packet using the sender's
+keys.  If the Media Distributor decrypts and re-encrypts with the
+same key and salt, it will result in the reuse of a (key, nonce)
+pair, undermining the security of GCM.
+
 ## Decrypting a Packet {#decrypt} 
 
 To decrypt a packet, the endpoint first decrypts and verifies using


### PR DESCRIPTION
This is an important security consideration for the re-encryption case, which doesn't appear to be covered by the current text.