### PR TITLE
Made changes per Ben's comments

### DIFF
--- a/private-media-framework/draft-ietf-perc-private-media-framework.md
+++ b/private-media-framework/draft-ietf-perc-private-media-framework.md
@@ -329,7 +329,7 @@ To enable all of the above, this framework defines the use of two
 security contexts and two associated encryption keys: an "inner" key
 (an E2E key distinct for each transmitted media flow) for authenticated
 encryption of RTP media between endpoints and an "outer" key (HBH key)
-known only to media distributor and the adjacent endpoint)
+known only to Media Distributor and the adjacent endpoint)
 for the hop between an endpoint and a Media Distributor or between Media
 Distributor.
 
@@ -369,7 +369,7 @@ keys. See [@keyinventory] for a description of the keys used in PERC
 and [@packetformat] for diagram of how encrypted RTP packets appear on the
 wire.
 
-RTCP can only be encrypted hop-by-hop, not end-to-end.  This framework
+RTCP is only encrypted hop-by-hop, not end-to-end.  This framework
 introduces no additional step for RTCP authenticated encryption, so
 the procedures needed are specified in [@!RFC3711] and use the same
 outer, hop-by-hop cryptographic context chosen in the Double operation
@@ -467,8 +467,8 @@ a secure DTLS association between each endpoint and the Key
 Distributor as shown the following figure.  The DTLS association
 between endpoints and the Key Distributor enables each endpoint to
 generate E2E and HBH keys and receive the Key Encryption Key (KEK)
-(i.e., EKT Key).  At the same time, the Key Distributor can securely
-provide the HBH key information to the Media Distributor.  The key
+(i.e., EKT Key).  At the same time, the Key Distributor securely
+provides the HBH key information to the Media Distributor.  The key
 information summarized here may include the SRTP master key, SRTP
 master salt, and the negotiated cryptographic transform.
 
@@ -504,10 +504,6 @@ with the Key Distributor.  The Media Distributor does not terminate
 the DTLS signaling, but instead forwards DTLS packets received
 from an endpoint on to the Key Distributor (and vice versa) via a
 tunnel established between Media Distributor and the Key Distributor.
-This tunnel is used to encapsulate the DTLS-SRTP signaling between the
-Key Distributor and endpoints is also used to convey HBH key
-information from the Key Distributor to the Media Distributor, so no
-additional protocol or interface is required.
 
 In establishing the DTLS association between endpoints and the
 Key Distributor, the endpoint **MUST** act as the DTLS client and the
@@ -515,6 +511,10 @@ Key Distributor **MUST** act as the DTLS server.  The Key Encryption Key (KEK)
 (i.e., EKT Key) is conveyed by the Key Distributor over the DTLS
 association to endpoints via procedures defined in EKT
 [@I-D.ietf-perc-srtp-ekt-diet] via the EKTKey message.
+
+The Key Distributor **MUST NOT** establish DTLS-SRTP associations with
+endpoints without first authenticating the Media Distributor tunneling the
+DTLS-SRTP packets from the endpoint.
 
 Note that following DTLS-SRTP procedures for the [@!I-D.ietf-perc-double]
 cipher, the endpoint generates both E2E and HBH encryption keys
@@ -568,9 +568,9 @@ endpoints that used the prior keys for a period of time after re-keying began.
 An endpoint **MAY** retain old keys until the end of the conference.
 
 Endpoints **MAY** follow the procedures in section 5.2 of [@RFC5764]
-to re-negotiate HBH keys as desired.  If new HBH keys are generated,
+to renegotiate HBH keys as desired.  If new HBH keys are generated,
 the new keys are also delivered to the Media Distributor following
-the procedures defined in [@I-D.ietf-perc-dtls-tunnel].
+the procedures defined in [@I-D.ietf-perc-dtls-tunnel] as one possible method.
 
 Endpoints **MAY** change the E2E encryption key used at
 any time.  Endpoints **MUST** generate a new E2E encryption key
@@ -637,7 +637,7 @@ authorized Key Distributor for this conference.
 The Key Distributor needs to know what endpoints are being added to a
 given conference. Thus, the Key Distributor and the Media Distributor
 need to know endpoint-to-conference mappings, which is enabled by
-exchanging a conference-specific unique identifier as defined in
+exchanging a conference-specific unique identifier defined in
 [@I-D.ietf-perc-dtls-tunnel].  How this unique identifier is assigned
 is outside the scope of this document.
 
@@ -701,15 +701,15 @@ material is for hop-by-hop operations, so that half of the key
 (corresponding to the least significant bits) is assigned internally as
 the HBH key.
 
-The Key Distributor informs the Media Distributor of the HBH key
-value via the tunnel protocol ([@I-D.ietf-perc-dtls-tunnel]).  The Key
-Distributor sends the least significant bits corresponding to the
+The Key Distributor informs the Media Distributor of the HBH key.  Specifically,
+the Key Distributor sends the least significant bits corresponding to the
 half of the keying material determined through DTLS-SRTP with the endpoint
-to the Media Distributor via the tunnel protocol.  A salt value is
+to the Media Distributor.  A salt value is
 generated along with the HBH key.  The salt is also longer than needed
 for hop-by-hop operations, thus only the least significant bits of the
 required length (i.e., half of the generated salt material) are sent to the
-media distributor via the tunnel protocol.
+Media Distributor.  One way to transmit this key and salt information
+is via the tunnel protocol defined in [@I-D.ietf-perc-dtls-tunnel].
 
 No two endpoints have the same HBH key, thus the Media Distributor
 **MUST** keep track each distinct HBH key (and the corresponding salt) and
@@ -877,10 +877,9 @@ Distributor may cascade to another legitimate Media Distributor
 creating a false version of the real conference.
 
 This attack is be mitigated by the false Media Distributor not being
-authenticated by the Key Distributor during the tunnel [@I-D.ietf-perc-dtls-tunnel]
-establishment. Without the tunnel in place, endpoints are unable to
-establish secure associations with the Key Distributor and
-receive the KEK, causing the conference to not proceed.
+authenticated by the Key Distributor.  They Key Distributor
+will fail to establish the secure association with the endpoint if
+the Media Distributor cannot be authenticated.
 
 ##   Media Distributor Attacks
 

--- a/private-media-framework/draft-ietf-perc-private-media-framework.md
+++ b/private-media-framework/draft-ietf-perc-private-media-framework.md
@@ -461,7 +461,7 @@ following way:
 ### Initial Key Exchange and Key Distributor
 
 The Media Distributor maintains a tunnel with the Key Distributor
-(e.g., using [@?I-D.ietf-perc-dtls-tunnel]), making it
+(e.g., using [@I-D.ietf-perc-dtls-tunnel]), making it
 possible for the Media Distributor to facilitate the establishment of
 a secure DTLS association between each endpoint and the Key
 Distributor as shown the following figure.  The DTLS association
@@ -570,7 +570,7 @@ An endpoint **MAY** retain old keys until the end of the conference.
 Endpoints **MAY** follow the procedures in section 5.2 of [@RFC5764]
 to re-negotiate HBH keys as desired.  If new HBH keys are generated,
 the new keys are also delivered to the Media Distributor following
-the procedures defined in [@!I-D.ietf-perc-dtls-tunnel].
+the procedures defined in [@I-D.ietf-perc-dtls-tunnel].
 
 Endpoints **MAY** change the E2E encryption key used at
 any time.  Endpoints **MUST** generate a new E2E encryption key
@@ -638,7 +638,7 @@ The Key Distributor needs to know what endpoints are being added to a
 given conference. Thus, the Key Distributor and the Media Distributor
 need to know endpoint-to-conference mappings, which is enabled by
 exchanging a conference-specific unique identifier as defined in
-[@!I-D.ietf-perc-dtls-tunnel].  How this unique identifier is assigned
+[@I-D.ietf-perc-dtls-tunnel].  How this unique identifier is assigned
 is outside the scope of this document.
 
 # PERC Keys
@@ -702,7 +702,7 @@ material is for hop-by-hop operations, so that half of the key
 the HBH key.
 
 The Key Distributor informs the Media Distributor of the HBH key
-value via the tunnel protocol ([@!I-D.ietf-perc-dtls-tunnel]).  The Key
+value via the tunnel protocol ([@I-D.ietf-perc-dtls-tunnel]).  The Key
 Distributor sends the least significant bits corresponding to the
 half of the keying material determined through DTLS-SRTP with the endpoint
 to the Media Distributor via the tunnel protocol.  A salt value is
@@ -877,7 +877,7 @@ Distributor may cascade to another legitimate Media Distributor
 creating a false version of the real conference.
 
 This attack is be mitigated by the false Media Distributor not being
-authenticated by the Key Distributor during the tunnel [@!I-D.ietf-perc-dtls-tunnel]
+authenticated by the Key Distributor during the tunnel [@I-D.ietf-perc-dtls-tunnel]
 establishment. Without the tunnel in place, endpoints are unable to
 establish secure associations with the Key Distributor and
 receive the KEK, causing the conference to not proceed.

--- a/private-media-framework/draft-ietf-perc-private-media-framework.md
+++ b/private-media-framework/draft-ietf-perc-private-media-framework.md
@@ -16,7 +16,7 @@
     [seriesInfo]
     status = "standard"
     name = "Internet-Draft"
-    value = "draft-ietf-perc-private-media-framework-07"
+    value = "draft-ietf-perc-private-media-framework-08"
     stream = "IETF"
 
     [[author]]
@@ -63,6 +63,7 @@
     #        Editorial corrections
     #   06 - Editorial improvements (https://github.com/ietf/perc-wg/pull/150)
     #   07 - Expiration refresh
+    #   08 - Address comments from Ben Campbell
     #
 
 %%%
@@ -87,24 +88,21 @@ flows from conference participants are not mixed, transcoded,
 transrated, recomposed, or otherwise manipulated by a Media
 Distributor, as might be the case with a traditional media server or
 multipoint control unit (MCU).  Instead, media flows transmitted by
-conference participants are simply forwarded by the Media Distributor
-to each of the other participants, often forwarding only a subset of
+conference participants are simply forwarded by Media Distributors
+to each of the other participants.  Media Distributors often forward only a subset of
 flows based on voice activity detection or other criteria.  In some
-instances, the Media Distributors may make limited modifications to
+instances, Media Distributors may make limited modifications to
 RTP [@!RFC3550] headers, for example, but the actual media content
 (e.g., voice or video data) is unaltered.
 
 An advantage of switched conferencing is that Media Distributors can
 be more easily deployed on general-purpose computing hardware,
 including virtualized environments in private and public clouds.
-Deploying conference resources in a public cloud environment might
-introduce a higher security risk.  Whereas traditional conference
-resources were usually deployed in private networks that were
-protected, cloud-based conference resources might be viewed as less
-secure since they are not always physically controlled by those who
-use them.  Additionally, there are usually several ports open to the
-public in cloud deployments, such as for remote administration, and so
-on.
+While virutalized public cloud environments have been viewed as less
+secure since resources are not always physically controlled by
+those who use them and since there are usually several ports open to
+the public, this draft aims to improve security so as to lower the barrier
+to taking advantage of those environments.
 
 This document defines a solution framework wherein media privacy is
 ensured by making it impossible for a media distributor to
@@ -126,10 +124,9 @@ security procedures defined for RTP with minimal enhancements.
 
 The key words "**MUST**", "**MUST NOT**", "**REQUIRED**", "**SHALL**",
 "**SHALL NOT**", "**SHOULD**", "**SHOULD NOT**", "**RECOMMENDED**",
-"**MAY**", and "**OPTIONAL**" in this document are to be interpreted
-as described in [@!RFC2119] when they appear in ALL CAPS.  These words
-may also appear in this document in lower case as plain English words,
-absent their normative meanings.
+"**NOT RECOMMENDED**", "**MAY**", and "**OPTIONAL**" in this document
+are to be interpreted as described in BCP 14 [@!RFC2119] [@!RFC8174]
+when, and only when, they appear in all capitals, as shown here.
 
 Additionally, this solution framework uses the following
 terms and acronyms:
@@ -146,8 +143,9 @@ include embedded user conferencing equipment or browsers on computers,
 media gateways, MCUs, media recording device and more that are in the
 trusted domain for a given deployment.
 
-Media Distributor (MD): An RTP middlebox that is not allowed to to
-have access to E2E encryption keys.  It operates according to the
+Media Distributor (MD): An RTP middlebox that forwards media flows
+and that is not allowed to to have access to E2E encryption keys.
+It operates according to the
 Selective Forwarding Middlebox RTP topologies [@RFC7667] per the
 constraints defined by the PERC system, which includes, but not limited
 to, having no access to RTP media unencrypted and having limits on what
@@ -180,7 +178,7 @@ multiple, separate physical devices.
 Please note that some entities classified as untrusted in the simple,
 general deployment scenario used most commonly in this document might
 be considered trusted in other deployments.  This document does not
-preclude such scenarios, but will keep the definitions and examples
+preclude such scenarios, but keeps the definitions and examples
 focused by only using the the simple, most general deployment
 scenario.
 
@@ -211,11 +209,11 @@ The architecture described in this framework document enables
 conferencing infrastructure to be hosted in domains, such as in a
 cloud conferencing provider's facilities, where the trustworthiness is
 below the level needed to assume the privacy of participant's media
-will not be compromised.  The conferencing infrastructure in such a
+is not compromised.  The conferencing infrastructure in such a
 domain is still trusted with reliably connecting the participants
 together in a conference, but not trusted with keying material needed
 to decrypt any of the participant's media.  Entities in such lower
-trustworthiness domains will simply be referred to as untrusted
+trustworthiness domains are referred to as untrusted
 entities from this point forward.
 
 It is important to understand that untrusted in this document does not
@@ -229,26 +227,26 @@ A Media Distributor forwards RTP flows between endpoints in the
 conference while performing per-hop authentication of each RTP packet.
 The Media Distributor may need access to one or more RTP headers or
 header extensions, potentially adding or modifying a certain subset.
-The Media Distributor will also relay secured messaging between the
-endpoints and the Key Distributor and will acquire per-hop key
+The Media Distributor also relays secured messaging between the
+endpoints and the Key Distributor and acquires per-hop key
 information from the Key Distributor.  The actual media content
-**MUST NOT** not be decryptable by a Media Distributor, so it is untrusted to
+must not be decryptable by a Media Distributor, as it is untrusted to
 have access to the E2E media encryption keys.  The key exchange
-mechanisms specified in this framework will prevent the Media Distributor
+mechanisms specified in this framework prevents the Media Distributor
 from gaining access to the E2E media encryption keys.
 
-An endpoint's ability to join a conference hosted by a Media
-Distributor **MUST NOT** alone be interpreted as being authorized to
+An endpoint's ability to connect to a conference serviced by a Media
+Distributor does imply that the endpoint is authorized to
 have access to the E2E media encryption keys, as the Media Distributor
 does not have the ability to determine whether an endpoint is
 authorized.  Instead, the Key Distributor is responsible for
-authenticating endpoints (e.g., using WebRTC Identity
-[@I-D.ietf-rtcweb-security-arch]) and determining their
-authorization to receive E2E media encryption keys.
+authenticating the endpoint (e.g., using WebRTC Identity
+[@I-D.ietf-rtcweb-security-arch]) and determining its
+authorization to receive E2E and HBH media encryption keys.
 
-A Media Distributor **MUST** perform its role in properly forwarding
+A Media Distributor must perform its role in properly forwarding
 media packets while taking measures to mitigate the adverse effects of
-denial of service attacks (refer to (#attacks)), etc, to a level equal
+denial of service attacks (refer to (#attacks)) to a level equal
 to or better than traditional conferencing (i.e. non-PERC)
 deployments.
 
@@ -283,11 +281,11 @@ encryption keys for one or more conferences.
 
 ### Endpoint
 
-An endpoint is considered trusted and will have access to E2E key
+An endpoint is considered trusted and has access to E2E key
 information.  While it is possible for an endpoint to be compromised,
 subsequently performing in undesired ways, defining endpoint
 resistance to compromise is outside the scope of this document.
-Endpoints will take measures to mitigate the adverse effects of denial
+Endpoints take measures to mitigate the adverse effects of denial
 of service attacks (refer to (#attacks)) from other entities,
 including from other endpoints, to a level equal to or better than
 traditional conference (i.e., non-PERC) deployments.
@@ -296,7 +294,7 @@ traditional conference (i.e., non-PERC) deployments.
 
 The Key Distributor, which may be colocated with an endpoint or exist
 standalone, is responsible for providing key information to endpoints
-for both end-to-end and hop-by-hop security and for providing key
+for both end-to-end (E2E) and hop-by-hop (HBH) security and for providing key
 information to Media Distributors for the hop-by-hop security.
 
 Interaction between the Key Distributor and the call processing
@@ -316,14 +314,14 @@ switch, hence not terminate, media.  It does not otherwise attempt to
 hide the fact that a conference between endpoints is taking place.
 
 This framework reuses several specified RTP security technologies,
-including SRTP [@!RFC3711], PERC EKT [@!I-D.ietf-perc-srtp-ekt-diet],
+including SRTP [@!RFC3711], EKT [@!I-D.ietf-perc-srtp-ekt-diet],
 and DTLS-SRTP [@!RFC5764].
 
 ## End-to-End and Hop-by-Hop Authenticated Encryption
 
 This solution framework focuses on the end-to-end privacy and
-integrity of the participant's media by limiting access of the
-end-to-end key information to trusted entities.  However, this
+integrity of the participant's media by limiting access to the
+E2E key information to trusted entities.  However, this
 framework does give a Media Distributor access to RTP headers and all
 or most header extensions, as well as the ability to modify a certain
 subset of those headers and to add header extensions.  Packets
@@ -336,7 +334,7 @@ security contexts and two associated encryption keys: an "inner" key
 encryption of RTP media between endpoints and an "outer" key (HBH key)
 known only to media distributor and the adjacent endpoint)
 for the hop between an endpoint and a Media Distributor or between Media
-Distributor.  
+Distributor.
 
 {#fig-e2e-and-hbh-keys-used align="center"}
 ~~~
@@ -365,8 +363,8 @@ Distributor.
 Figure: E2E and HBH Keys Used for Authenticated Encryption of SRTP
 Packets
 
-The PERC Double transform [@!I-D.ietf-perc-double] enables endpoints
-to perform encryption using both the E2E and HBH contexts while
+The Double transform [@!I-D.ietf-perc-double] enables endpoints
+to perform encryption using both the end-to-end and hop-by-hop contexts while
 still preserving the same overall interface as other SRTP
 transforms.  The Media Distributor simply uses the corresponding
 normal (single) AES-GCM transform, keyed with the appropriate HBH
@@ -383,43 +381,48 @@ described above.
 ## E2E Key Confidentiality
 
 To ensure the confidentiality of E2E keys shared between endpoints,
-endpoints will make use of a common Key Encryption Key (KEK) that is
+endpoints use a common Key Encryption Key (KEK) that is
 known only by the trusted entities in a conference.  That KEK, defined
-in the PERC EKT [@!I-D.ietf-perc-srtp-ekt-diet] as the EKT Key, will be
+in the EKT [@!I-D.ietf-perc-srtp-ekt-diet] specification as the EKT Key, is
 used to subsequently encrypt the SRTP master key used for E2E
 authenticated encryption of media sent by a given endpoint.
-Each endpoint in the conference will create a random SRTP master
-key for E2E authenticated encryption, thus participants in the conference
-**MUST** keep track of the E2E keys received via the Full EKT Field for
-each distinct SSRC in the conference so that it can properly decrypt
-received media.  Note, too, that an endpoint may change its E2E key at any
+Each endpoint in the conference creates an SRTP master
+key for E2E authenticated encryption and
+keep track of the E2E keys received via the Full EKT Tag for
+each distinct synchronization source (SSRC) in the conference so that it
+can properly decrypt received media.  Endpoint may change its E2E key at any
 time and advertise that new key to the conference as specified in
 [@!I-D.ietf-perc-srtp-ekt-diet].
 
 ## E2E Keys and Endpoint Operations
 
-Any given RTP media flow can be identified by its SSRC, and endpoints
+Any given RTP media flow can be identified by its SSRC, and an endpoint
 might send more than one at a time and change the mix of media flows
 transmitted during the life of a conference.
 
-Thus, endpoints **MUST** maintain a list of SSRCs from received RTP
+Thus, an endpoint **MUST** maintain a list of SSRCs from received RTP
 flows and each SSRC's associated E2E key information.  Following a
-change in an E2E key, prior E2E keys **SHOULD** be retained by receivers
+change in an E2E key, prior E2E keys **SHOULD** be retained by the endpoint
 for a period long enough to ensure that late-arriving or out-of-order
-packets from the endpoint can be successfully decrypted.  Receiving
-endpoints **MUST** discard old E2E keys no later than when it leaves the
+packets can be successfully decrypted.  An
+endpoint **MUST** discard old E2E keys no later than when it leaves the
 conference.
 
 If there is a need to encrypt one or more RTP header extensions
-end-to-end, an encryption key is derived from the end-to-end SRTP
+end-to-end, the endpoint derives an encryption key from the E2E SRTP
 master key to encrypt header extensions as per [@!RFC6904].  The Media
-Distributor will not be able use the information contained in those
+Distributor is unable use the information contained in those
 header extensions encrypted with an E2E key.
 
-## HBH Keys and Hop Operations
+> Editor's Note: I believe E2E encryption of header extensions is now
+  off the table with Double.  Shall we delete the above paragraph? Or is
+  this still an option?  We have not discussed how this would be signaled
+  and I don't think this is described in Double.
 
-To ensure the integrity of transmitted media packets, this framework
-requires that every packet be authenticated hop-by-hop (HBH) between
+## HBH Keys and Per-hop Operations
+
+To ensure the integrity of transmitted media packets, it is
+**REQUIRED** that every packet be authenticated hop-by-hop between
 an endpoint and a Media Distributor, as well between Media
 Distributors.  The authentication key used for hop-by-hop
 authentication is derived from an SRTP master key shared only on the
@@ -429,7 +432,7 @@ use the same SRTP master key.
 Using hop-by-hop authentication gives the Media Distributor the
 ability to change certain RTP header values.  Which values the Media
 Distributor can change in the RTP header are defined in
-[@!I-D.ietf-perc-double].  RTCP can only be encrypted HBH, giving the
+[@!I-D.ietf-perc-double].  RTCP can only be encrypted hop-by-hop, giving the
 Media Distributor the flexibility to forward RTCP content unchanged,
 transmit compound RTCP packets or to initiate RTCP packets for
 reporting statistics or conveying other information.  Performing
@@ -437,12 +440,12 @@ hop-by-hop authentication for all RTP and RTCP packets also helps
 provide replay protection (see (#attacks)).
 
 If there is a need to encrypt one or more RTP header extensions
-hop-by-hop, an encryption key is derived from the hop-by-hop SRTP
-master key to encrypt header extensions as per [@!RFC6904].  This will
-still give the Media Distributor visibility into header extensions,
+hop-by-hop, the endpoint derives an encryption key from the HBH SRTP
+master key to encrypt header extensions as per [@!RFC6904].  This
+still gives the Media Distributor visibility into header extensions,
 such as the one used to determine audio level [@RFC6464] of conference
 participants.  Note that when RTP header extensions are encrypted, all
-hops - in the untrusted domain at least - will need to decrypt and
+hops need to decrypt and
 re-encrypt these encrypted header extensions.
 
 ## Key Exchange
@@ -456,21 +459,21 @@ following way:
 
 * The E2E key that an endpoint uses to send SRTP media can either be
   set from DTLS or chosen by the endpoint.  It is then distributed
-  to other endpoints in a Full EKT Field, encrypted under an EKTKey
+  to other endpoints in a Full EKT Tag, encrypted under an EKT Key
   provided to the client by the Key Distributor within the DTLS
   channel they negotiated.
 
 * Each E2E key that an endpoint uses to receive SRTP media is set
-  by receiving a Full EKT Field from another endpoint.
+  by receiving a Full EKT Tag from another endpoint.
 
 ### Initial Key Exchange and Key Distributor
 
-The Media Distributor maintains a tunnel with the Key Distrubutor
+The Media Distributor maintains a tunnel with the Key Distributor
 (e.g., using [@?I-D.ietf-perc-dtls-tunnel]), making it
 possible for the Media Distributor to facilitate the establishment of
 a secure DTLS association between each endpoint and the Key
 Distributor as shown the following figure.  The DTLS association
-between endpoints and the Key Distributor will enable each endpoint to
+between endpoints and the Key Distributor enables each endpoint to
 generate E2E and HBH keys and receive the Key Encryption Key (KEK)
 (i.e., EKT Key).  At the same time, the Key Distributor can securely
 provide the HBH key information to the Media Distributor.  The key
@@ -496,26 +499,33 @@ master salt, and the negotiated cryptographic transform.
 ~~~
 Figure: Exchanging Key Information Between Entities
 
-Endpoints will establish a DTLS-SRTP [@!RFC5764] association over the
+In addition to the secure tunnel between the Media Distributor and the
+Key Distributor, there are two additional types of security associations
+utilized as a part of the key exchange as discussed in the following
+paragraphs.  One is a DTLS-SRTP association between an endpoint and the Key
+Distributor (with packets passing through the Media Distributor) and the
+other is a DTLS-SRTP association between peer Media Distributors.
+
+Endpoints establish a DTLS-SRTP [@!RFC5764] association over the
 RTP session's media ports for the purposes of key information exchange
-with the Key Distributor.  The Media Distributor will not terminate
-the DTLS signaling, but will instead forward DTLS packets received
+with the Key Distributor.  The Media Distributor does not terminate
+the DTLS signaling, but instead forwards DTLS packets received
 from an endpoint on to the Key Distributor (and vice versa) via a
 tunnel established between Media Distributor and the Key Distributor.
 This tunnel is used to encapsulate the DTLS-SRTP signaling between the
-Key Distributor and endpoints will also be used to convey HBH key
+Key Distributor and endpoints is also used to convey HBH key
 information from the Key Distributor to the Media Distributor, so no
 additional protocol or interface is required.
 
 In establishing the DTLS association between endpoints and the
-Key Distributor, the endpoint MUST act as the DTLS client and the
-Key Distributor MUST act as the DTLS server.  The Key Encryption Key (KEK)
+Key Distributor, the endpoint **MUST** act as the DTLS client and the
+Key Distributor **MUST** act as the DTLS server.  The Key Encryption Key (KEK)
 (i.e., EKT Key) is conveyed by the Key Distributor over the DTLS
-association to endpoints via procedures defined in PERC EKT
+association to endpoints via procedures defined in EKT
 [@I-D.ietf-perc-srtp-ekt-diet] via the EKTKey message.
 
 Note that following DTLS-SRTP procedures for the [@!I-D.ietf-perc-double]
-cipher, the endpoint will generate both E2E and HBH encryption keys
+cipher, the endpoint generates both E2E and HBH encryption keys
 and salt values.  Endpoints **MAY** use the DTLS-SRTP generated E2E key for transmission
 or **MAY** generate a fresh E2E key.  In either case, the generated SRTP
 master salt for E2E encryption **MUST** be replaced with the salt value
@@ -533,9 +543,9 @@ facilitate establishing a HBH key for use between Media Distributors.
 ### Key Exchange during a Conference
 
 Following the initial key information exchange with the Key
-Distributor, an endpoint will be able to encrypt media end-to-end with
+Distributor, an endpoint is able to encrypt media end-to-end with
 an E2E key, sending that E2E key to other endpoints encrypted with the
-KEK, and will be able to encrypt and authenticate RTP packets
+KEK, and is able to encrypt and authenticate RTP packets
 using a HBH key.  The procedures defined do not allow the Media
 Distributor to gain access to the KEK information, preventing it from
 gaining access to any endpoint's E2E key and subsequently decrypting
@@ -548,37 +558,53 @@ re-keyed is outside the scope of this document, but this framework
 does accommodate re-keying during the life of a conference.
 
 When a Key Distributor decides to re-key a conference, it transmits a
-specific message defined in PERC EKT [@!I-D.ietf-perc-srtp-ekt-diet] to
-each of the conference participants.  The endpoint **MUST** create a
+new EKTKey message [@!I-D.ietf-perc-srtp-ekt-diet] to
+each of the conference participants containing the new EKT Key.
+Upon receipt of the new EKT Key, the endpoint **MUST** create a
 new SRTP master key and prepare to send that key inside a Full EKT
-Field using the new EKTKey.  Since it may take some time for all of the
-endpoints in conference to finish re-keying, senders **MUST** delay a
-short period of time before sending media encrypted with the new
-master key, but it **MUST** be prepared to make use of the information
-from a new inbound EKT Key immediately. See Section 2.2.2 of
-[@!I-D.ietf-perc-srtp-ekt-diet].
+Field using the new EKT Key as per Section 4.5 of [@!I-D.ietf-perc-srtp-ekt-diet].
+Since it may take some time for all of the endpoints in conference to finish
+re-keying, senders **MUST** delay a short period of time before sending media
+encrypted with the new master key and before utilizing the new EKT Key
+(continuing using the old EKT Key temporarily), but it **MUST** be prepared to
+process packets containing the new EKT Key immediately. The EKT SPI field can
+be used to differentiate between tags encrypted with the old and new keys.
+
+> Editor's Note: Now much time is a "short period of time"? It would be
+  really nice if the EKTKey message contained this delay. And the KD knows
+  roughly how long it would take to send out messages. For a two-party
+  conference, this might be 100ms, but for a large conference it might be
+  several seconds.
+
+After re-keying, an endpoint should retain old SRTP master keys and EKT Key
+for a period of time for the purpose of ensuring it can decrypt packets.
+The time period to retain old keys is not specified, but they should be
+retained at least for the period of time required to re-key the conference
+or handle late-arriving or out-of-order packets.  A period of 60s should be
+considered a generous retention period, but an endpoint **MAY** retain old
+keys until the end of the conference.
 
 Endpoints **MAY** follow the procedures in section 5.2 of [@RFC5764]
 to re-negotiate HBH keys as desired.  If new HBH keys are generated,
 the new keys are also delivered to the Media Distributor following
 the procedures defined in [@!I-D.ietf-perc-dtls-tunnel].
 
-Endpoints are at liberty to change the E2E encryption key used at
+Endpoints **MAY** change the E2E encryption key used at
 any time.  Endpoints **MUST** generate a new E2E encryption key
 whenever it receives a new EKT Key.  After switching to a new key,
-the new key will be conveyed to other endpoints in the conference
+the new key is conveyed to other endpoints in the conference
 in RTP/RTCP packets per [@!I-D.ietf-perc-srtp-ekt-diet].
 
 # Authentication
 
-It is important to this solution framework that the entities can 
+It is important to this solution framework that the entities can
 validate the authenticity of other entities, especially the Key
 Distributor and endpoints.  The details of this are outside the scope
 of specification but a few possibilities are discussed in the
-following sections.  The key requirements is that endpoints can verify
-they are connected to the correct Key Distributor for the conference
-and the Key Distributor can verify the endpoints are the correct
-endpoints for the conference.
+following sections.  The key requirements are that an endpoint can verify
+it is connected to the correct Key Distributor for the conference
+and the Key Distributor can verify the endpoint is the correct
+endpoint for the conference.
 
 Two possible approaches to solve this are Identity Assertions and
 Certificate Fingerprints.
@@ -609,11 +635,11 @@ As a concrete example, SIP [@RFC3261] and SDP [@RFC4566] can be used
 to convey the fingerprint information per [@RFC5763].  An endpoint's
 SIP User Agent would send an INVITE message containing SDP for the
 media session along with the endpoint's certificate fingerprint, which
-can be signed using the procedures described in [@RFC4474] for the
+can be signed using the procedures described in [@RFC8224] for the
 benefit of forwarding the message to other entities by the Focus
-[@RFC4353].  Other entities can now verify the fingerprints match the
+[@RFC4353].  Other entities can verify the fingerprints match the
 certificates found in the DTLS-SRTP connections to find the identity
-of the far end of the DTLS-SRTP connection and check that is the
+of the far end of the DTLS-SRTP connection and verify that is the
 authorized entity.
 
 Ultimately, if using session signaling, an endpoint's certificate
@@ -627,35 +653,25 @@ authorized Key Distributor for this conference.
 
 The Key Distributor needs to know what endpoints are being added to a
 given conference. Thus, the Key Distributor and the Media Distributor
-will need to know endpoint-to-conference mappings, which is enabled by
+need to know endpoint-to-conference mappings, which is enabled by
 exchanging a conference-specific unique identifier as defined in
 [@!I-D.ietf-perc-dtls-tunnel].  How this unique identifier is assigned
 is outside the scope of this document.
 
 # Security Considerations {#attacks}
 
-This framework, and the individual protocols defined to support it,
-must take care to not increase the exposure to Denial of Service (DoS)
-attacks by untrusted or third-party entities and should take measures
-to mitigate, where possible, more serious DoS attacks from on-path and
-off-path attackers.
-
-The following section enumerates the kind of attacks that will be
-considered in the development of this framework's solution.
-
 ##  Third Party Attacks
 
-On-path attacks are mitigated by HBH integrity protection and
+On-path attacks are mitigated by hop-by-hop integrity protection and
 encryption.  The integrity protection mitigates packet modification
 and encryption makes selective blocking of packets harder, but not
 impossible.
 
 Off-path attackers may try connecting to different PERC entities and
 send specifically crafted packets.  A successful attacker might be
-able to get the Media Distributor to forward such packets.  If not
-making use of HBH authentication on the Media Distributor, such an
-attack could only be detected in the receiving endpoints where the
-forged packets would finally be dropped.
+able to get the Media Distributor to forward such packets.  The Media
+Distributor mitigates such an attack by performing hop-by-hop authentication
+and discarding packets that fail authentication.
 
 Another potential attack is a third party claiming to be a Media
 Distributor, fooling endpoints in to sending packets to the false
@@ -666,8 +682,8 @@ Distributor may cascade to another legitimate Media Distributor
 creating a false version of the real conference.
 
 This attack can be mitigated by the false Media Distributor not being
-authenticated by the Key Distributor during PERC Tunnel
-establishment. Without the tunnel in place, endpoints will not
+authenticated by the Key Distributor during the tunnel [@!I-D.ietf-perc-dtls-tunnel]
+establishment. Without the tunnel in place, endpoints are unable to
 establish secure associations with the Key Distributor and
 receive the KEK, causing the conference to not proceed.
 
@@ -678,33 +694,27 @@ ways.
 
 ###   Denial of service
 
-Any modification of the end-to-end authenticated data will result in
+The simplest form of attack is simply discarding received packets.
+There is no mitigation for Media Distributors that fail to forward
+media packets.
+
+Any modification of the end-to-end authenticated data results in
 the receiving endpoint getting an integrity failure when performing
 authentication on the received packet.
 
 The Media Distributor can also attempt to perform resource consumption
 attacks on the receiving endpoint.  One such attack would be to insert
 random SSRC/CSRC values in any RTP packet with an inband
-key-distribution message attached (i.e., Full EKT Field).  Since such
+key-distribution message attached (i.e., Full EKT Tag).  Since such
 a message would trigger the receiver to form a new cryptographic
 context, the Media Distributor can attempt to consume the receiving
-endpoints resources.
-
-Another denial of service attack is where the Media Distributor
-rewrites the PT field to indicate a different codec.  The effect of
-this attack is that any payload packetized and encoded according to
-one RTP payload format is then processed using another payload format
-and codec.  Assuming that the implementation is robust to random
-input, it is unlikely to cause crashes in the receiving
-software/hardware.  However, it is not unlikely that such rewriting
-will cause severe media degradation.
-
-For audio formats, this attack is likely to cause highly disturbing
-audio and/or can be damaging to hearing and playout equipment.
+endpoints resources.  While E2E authentication would fail and the
+cryptographic context would be destroyed, the key derivation operation
+would nonetheless consume some computational resources.
 
 ###  Replay Attack
 
-Replay attack is when an already received packets from a previous
+A replay attack is when an already received packets from a previous
 point in the RTP stream is replayed as new packet.  This could, for
 example, allow a Media Distributor to transmit a sequence of packets
 identified as a user saying "yes", instead of the "no" the user
@@ -739,8 +749,8 @@ multiple media sources splices one media stream into the other.  If
 the Media Distributor is able to change the SSRC without the receiver
 having any method for verifying the original source ID, then the Media
 Distributor could first deliver stream A and then later forward stream
-B under the same SSRC as stream A was previously using.  Not allowing
-the Media Distributor to change the SSRC mitigates this attack.
+B under the same SSRC as stream A was previously using.  By not allowing
+the Media Distributor to change the SSRC, PERC mitigates this attack.
 
 # IANA Considerations
 
@@ -757,7 +767,7 @@ a co-author.
 
 # PERC Key Inventory {#keyinventory}
 
-PERC specifies the use of a number of different keys and, understandably,
+PERC specifies the use of several different keys and, understandably,
 it looks complicated or confusing on the surface.  This section summarizes
 the various keys used in the system, how they are generated, and what
 purpose they serve.
@@ -787,7 +797,7 @@ Figure: Key Inventory
 As you can see, the number key types is very small.  However, what
 can be challenging is keeping track of all of the distinct E2E keys as
 the conference grows in size.  With 1,000 participants in a conference,
-there will be 1,000 distinct SRTP master keys, all of which share the
+there would be at least 1,000 distinct SRTP master keys, all of which share the
 same master salt.  Each of those keys are passed through the KDF defined
 in [@RFC3711] to produce the actual encryption and authentication keys.
 Complicating key management is the fact that the KEK can change and,
@@ -796,53 +806,45 @@ course, there is a new SRTP master salt to go with those keys.
 Endpoints have to retain old keys for a period of time to ensure they
 can properly decrypt late-arriving or out-of-order packets.
 
-The time required to retain old keys (either EKT Keys or SRTP master keys)
-is not specified, but they should be retained at least for the period of
-time required to re-key the conference or handle late-arriving or
-out-of-order packets.  A period of 60s should be considered a
-generous retention period, but endpoints may keep old keys on hand
-until the end of the conference.
-
-Or more detailed explanation of each of the keys follows.
+A more detailed explanation of each of the keys follows.
 
 ## DTLS-SRTP Exchange Yields HBH Keys
 
 The first set of keys acquired are for hop-by-hop encryption and
-decryption.  Assuming the use of Double [@!I-D.ietf-perc-double], the
+decryption.  Per the Double [@!I-D.ietf-perc-double] procedures, the
 endpoint would perform DTLS-SRTP exchange with the key distributor
 and receive a key that is, in fact, "double" the size that is needed.
-Per the Double specification, the E2E part is the first half of the key,
-so the endpoint will just discard that information in PERC.  It is not
-used.  The second half of the key material is for HBH operations, so
+The E2E part is the first half of the key,
+so the endpoint can discard that information when generating its own key.
+The second half of the key material is for hop-by-hop operations, so
 that half of the key (corresponding to the least significant bits) is
 assigned internally as the HBH key.
 
-The media distributor doesn't perform DTLS-SRTP, but it is at this point
-that the key distributor will inform the media distributor of the HBH key
-value via the tunnel protocol ([@!I-D.ietf-perc-dtls-tunnel]).  The key
-distributor will send the least significant bits corresponding to the
+The Key Distributor informs the Media Distributor of the HBH key
+value via the tunnel protocol ([@!I-D.ietf-perc-dtls-tunnel]).  The Key
+Distributor sends the least significant bits corresponding to the
 half of the keying material determined through DTLS-SRTP with the endpoint
-to the media distributor via the tunnel protocol.  There is a salt
+to the Media Distributor via the tunnel protocol.  There is a salt
 generated along with the HBH key.  The salt is also longer than needed
-for HBH operations, thus only the least significant bits of the required
+for hop-by-hop operations, thus only the least significant bits of the required
 length (i.e., half of the generated salt material) are sent to the media
 distributor via the tunnel protocol.
 
-No two endpoints will have the same HBH key, thus the media distributor
+No two endpoints have the same HBH key, thus the Media Distributor
 must keep track each distinct HBH key (and the corresponding salt) and
 use it only for the specified hop.
 
-This key is also used for HBH encryption of RTCP.  RTCP is not
+This key is also used for hop-by-hop encryption of RTCP.  RTCP is not
 end-to-end encrypted in PERC.
 
 ## The Key Distributor Transmits the KEK (EKT Key)
 
-Via the aforementioned DTLS-SRTP association, the key distributor will
-send the endpoint the KEK (i.e., EKT Key per
+Via the aforementioned DTLS-SRTP association, the key distributor
+sends the endpoint the KEK (i.e., EKT Key per
 [@!I-D.ietf-perc-srtp-ekt-diet]).  This key is known only to
 the key distributor and endpoints.  This key is the most important to
 protect since having knowledge of this key (and the SRTP master salt
-transmitted as a part of the same message) will allow an entity to
+transmitted as a part of the same message) allows an entity to
 decrypt any media packet in the conference.
 
 Note that the key distributor can send any number of EKT Keys to
@@ -857,39 +859,37 @@ The SRTP master salt to be used by the endpoint is transmitted along
 with the EKT Key.  All endpoints in the conference utilize
 the same SRTP master salt that corresponds with a given EKT Key.
 
-The EKT Field in media packets is encrypted using a cipher specified
+The Full EKT Tag in media packets is encrypted using a cipher specified
 via the EKTKey message (e.g., AES Key Wrap with a 128-bit key).  This
 cipher is different than the cipher used to protect media and is only
-used to encrypt the endpoint's SRTP master key (and other EKT Field data
+used to encrypt the endpoint's SRTP master key (and other EKT Tag data
 as per [@!I-D.ietf-perc-srtp-ekt-diet]).
 
 The media distributor is not given the KEK (i.e., EKT Key).
 
 ## Endpoints fabricate an SRTP Master Key
 
-As stated earlier, the E2E key determined via DTLS-SRTP **MAY** be
+As stated earlier, the E2E key determined via DTLS-SRTP may be
 discarded in favor of a locally-generated SRTP master key.  While the
 DTLS-SRTP-derived key could be used, the fact that an endpoint might
 need to change the SRTP master key periodically or is forced to change the
 SRTP master key as a result of the EKT key changing means using it has
-only limited utility.  To reduce complexity, PERC **RECOMMENDS** that
-endpoints create random SRTP master keys locally to be used for E2E
-encryption.
+only limited utility.
 
 This locally-generated SRTP master key is used along with the master salt
 transmitted to the endpoint from the key distributor via the EKTKey
 message to encrypt media end-to-end.
 
-Since the media distributor is not involved in E2E functions, it will not
+Since the media distributor is not involved in E2E functions, it does not
 create this key nor have access to any endpoint's E2E key.  Note, too,
 that even the key distributor is unaware of the locally-generated E2E keys
 used by each endpoint.
 
-The endpoint will transmit its E2E key to other endpoints in the conference
-by periodically including it in SRTP packets in a Full EKT Field.  When
-placed in the Full EKT Field, it is encrypted using the EKT Key provided
+The endpoint transmits its E2E key to other endpoints in the conference
+by periodically including it in SRTP packets in a Full EKT Tag.  When
+placed in the Full EKT Tag, it is encrypted using the EKT Key provided
 by the key distributor.  The master salt is not transmitted, though,
-since all endpoints will have received the same master salt via the EKTKey
+since all endpoints receive the same master salt via the EKTKey
 message.  The recommended frequency with which an endpoint transmits its
 SRTP master key is specified in [@!I-D.ietf-perc-srtp-ekt-diet].
 
@@ -900,11 +900,11 @@ All endpoints have knowledge of the KEK.
 Every HBH key is distinct for a given endpoint, thus Endpoint A and
 endpoint B do not have knowledge of the other's HBH key.
 
-Each endpoint generates its own E2E Key (SRTP master key), thus the
-key distinct per endpoint.  This key is transmitted (encrypted) via
-the EKT Field to other endpoints.  Endpoints that receive media from
-a given transmitting endpoint will therefore have knowledge of the
-transmitter's E2E key.
+Each endpoint generates its own E2E Key (SRTP master key), thus
+distinct per endpoint.  This key is transmitted (encrypted) via
+the Full EKT Tag to other endpoints.  Endpoints that receive media from
+a given transmitting endpoint gains knowledge of the
+transmitter's E2E key via the Full EKT Tag.
 
 To summarize the various keys and which entity is in possession
 of a given key, refer to [@fig-who-has-what-key].
@@ -930,37 +930,44 @@ Figure: Keys per Entity
 # PERC Packet Format {#packetformat}
 
 [@fig-perc-packet-format] presents a complete picture of what a PERC
-packet looks like when transmitted over the wire.
+packet looks like when transmitted over the wire.  The packet format
+shown is encrypted using the Double cryptographic transform with an
+EKT Tag appended to the end.
 
 {#fig-perc-packet-format align="center"}
 ~~~
-   0                   1                   2                   3
-   0 1 2 3 4 5 6 7 8 9 0 1 2 3 4 5 6 7 8 9 0 1 2 3 4 5 6 7 8 9 0 1
-  +-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+
-A |V=2|P|X|  CC   |M|     PT      |       sequence number         |
-  +-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+
-A |                           timestamp                           |
-  +-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+
-A |           synchronization source (SSRC) identifier            |
-  +=+=+=+=+=+=+=+=+=+=+=+=+=+=+=+=+=+=+=+=+=+=+=+=+=+=+=+=+=+=+=+=+
-A |            contributing source (CSRC) identifiers             |
-A |                               ....                            |
-  +-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+
-A |                    RTP extension (OPTIONAL)                   |
-A |                      (including the OHB)                      |
-  +-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+
-C :                                                               :
-C :                       Ciphertext Payload                      :
-C :                                                               :
-  +-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+
-R :                                                               :
-R :                        EKT Field                              :
-R :                                                               :
-  +-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+
-
-             C = Ciphertext (encrypted and authenticated)
-             A = Associated Data (authenticated only)
-             R = neither encrypted nor authenticated, added
-                 after Authenticated Encryption completed
+     0                   1                   2                   3
+     0 1 2 3 4 5 6 7 8 9 0 1 2 3 4 5 6 7 8 9 0 1 2 3 4 5 6 7 8 9 0 1
+    +-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+<++
+    |V=2|P|X|  CC   |M|     PT      |       sequence number         | IO
+    +-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+ IO
+    |                           timestamp                           | IO
+    +-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+ IO
+    |           synchronization source (SSRC) identifier            | IO
+    +=+=+=+=+=+=+=+=+=+=+=+=+=+=+=+=+=+=+=+=+=+=+=+=+=+=+=+=+=+=+=+=+ IO
+    |            contributing source (CSRC) identifiers             | IO
+    |                               ....                            | IO
+    +-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+<+O
+    |                    RTP extension (OPTIONAL) ...               | |O
++>+>+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+<+O
+O I |                          payload  ...                         | IO
+O I |                               +-------------------------------+ IO
+O I |                               | RTP padding   | RTP pad count | IO
+O +>+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+<+O
+O | |                    E2E authentication tag                     | |O
+O | +-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+ |O
+O | |                            OHB ...                            | |O
++>| +-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+ |+
+| | |                    HBH authentication tag                     | ||
+| | +-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+ ||
+| | |   EKT Tag ...   | R                                             ||
+| | +-+-+-+-+-+-+-+-+-+ |                                             ||
+| |                     +- Neither encrypted nor authenticated;       ||
+| |                        appended after Double is performed         ||
+| |                                                                   ||
+| |                                                                   ||
+| +- E2E Encrypted Portion               E2E Authenticated Portion ---+|
+|                                                                      |
++--- HBH Encrypted Portion               HBH Authenticated Portion ----+
 ~~~
 Figure: PERC Packet Format

--- a/private-media-framework/draft-ietf-perc-private-media-framework.md
+++ b/private-media-framework/draft-ietf-perc-private-media-framework.md
@@ -46,7 +46,7 @@
     fullname="Christian Groves"
     organization = "Independent"
       [author.address]
-      email = "Christian.Groves@nteczone.com"
+      email = "cngroves.std@gmail.com"
       [author.address.postal]
       city = "Melbourne"
       country = "Australia"

--- a/private-media-framework/draft-ietf-perc-private-media-framework.md
+++ b/private-media-framework/draft-ietf-perc-private-media-framework.md
@@ -400,7 +400,7 @@ transmitted during the life of a conference.
 Thus, an endpoint **MUST** maintain a list of SSRCs from received RTP
 flows and each SSRC's associated E2E key information.  An endpoint **MUST**
 discard old E2E keys no later than when it leaves the conference
-(see Section [@keyexchange]).
+(see [@keyexchange]).
 
 If there is a need to encrypt one or more RTP header extensions
 end-to-end, the endpoint derives an encryption key from the E2E SRTP


### PR DESCRIPTION
Ben provided a number of review comments.  I tried to address all of them, but I still have these outstanding and would like input.

> §2, definition of MD: It seems like this definition is a little too focused on the PERC trust model, and leaves out the definition of it as a middlebox that forwards the active stream without modification. (I guess that’s caught in the reference to 7667, but it would be better to include the core of the definition here, rather than imply it by reference.

I added a few words, but we cannot say “forwards the active stream without modification” since what gets forwarded is not specified (i.e., the box decides which of any number of streams to forward per its logic) and since the RTP packets are certainly subject to modification. (The media content itself cannot be altered, but the RTP packet is.)  How can we better satisfy this comment?

> §3.1.2, last paragraph: "In any deployment scenario where the call processing function is
considered trusted, the call processing function MUST ensure the
integrity of received messages before forwarding to other entities.”
 
> Please describe why that is important in a PERC environment.

It’s not more or less important, and irrelevant to PERC, per se. I cannot think of why this sentence was added. Should we remove this paragraph?

> §4.3: "prior E2E keys SHOULD be retained”
 
> I think there’s some disagreement internal to this document, and between this and EKT (and maybe double?). Please see related comment 0n section 4.5.2

What is this?  Note that there was another suggestion to move some non-normative test that talks about key retention into the main body.  I did that.  But, I'm not sure what the disagreement is here.

> §4.4, 2nd paragraph: "Using hop-by-hop authentication gives the Media Distributor the
ability to change certain RTP header values.”
That’s not really a true statement. It’s the lack of E2E authentication that enables that. It seems like the real point is that, since we can’t use E2E authentication, HBH authentication is better than nothing.

Actually, we have E2E auth, too. Perhaps this isn’t clearly stated? There is a section titled “End-to-End and Hop-by-Hop Authenticated Encryption” that intended to make that clear.
 
> §4.4, 3rd paragraph: "If there is a need to encrypt one or more RTP header extensions hopby-
hop, ...” : Is that optional?

I would say “yes” since most endpoints today do not encrypt header extensions (in spite of the fact there are procedures defined for it.) And, that language is compatible with the Double draft.  This would require some agreement between hops, but I assume that is outside the scope of this document (as it’s a call signaling matter).  Any change needed here?

> §4.5.1, 2nd to last paragraph: "Endpoints MAY use the DTLSSRTP
generated E2E key for transmission or MAY generate a fresh E2E
key.”: They have to do one or the other, right? That wording allows then to do neither.

> PJ: This is OK. Whatever key is selected will be conveyed to other parties via EKT.

> §4.5.2, 3rd paragraph:
 
> I think there’s some disagreement on the normative keywords for delaying the switch to new keys. I discussed this offline with Richard, and he replied with the following:
 
> There's sort of a conflict here. The crux is here:
 
```
Since it may take some time for all of the
endpoints in conference to finish re-keying, senders MUST delay a
short period of time before sending media encrypted with the new
master key, but it MUST be prepared to make use of the information
from a new inbound EKT Key immediately.
```
 
> The first part talks about media keys, which conflicts with EKT; it should probably be deleted. The second part is about processing EKT tags, and should be kept. So we probably end up with something like the following:
 
```
In order to allow time for all endpoints in the conference to receive the new keys,
the sender should follow the recommendations in Section XXX of [I-D.ietf-perc-srtp-ekt-diet].
On receiving a new EKT Key, endpoints MUST be prepared to decrypt EKT tags using the
new key. The EKT SPI field can be used to differentiate between tags encrypted with
the old and new keys.
```

I changed this text quite a bit and added an editor’s note. Would like opinions.
 
> §5.2, 2nd paragraph: If the fingerprint is signed, does the entire signaling network still need to be trusted? Also, should the reference to 4474 be 8224?

A SIP proxy could certainly be untrusted. It’s just important that the endpoint can verify the signature of messages received.  I’m not sure what else we need to say here.

> §6.2.1: This section seems odd to me. I understand not trusting the MD to keep communication confidential or to not tamper with it, etc. But if the MD wants to deny service, it can find much easier ways. For example, simply not forwarding packets.

I think it is important to understand that a malicious MD could crash an endpoint if precautions are not taken. But, the point about merely discarding packets is entirely correct.  That’s the simplest method.  I made a few changes in this section.

> Editorial Comments:
 
> General: I found the draft to have some issues with flow and fragmentation. I expected this draft give a big-picture overview tying together the moving parts of PERC in a way that tells me how they work together. I was surprised to find that the text that does that was relegated to the appendices, which I usually see reserved for more optional reading. I recommend promoting the appendix text into a non-normative introduction. (If you follow this recommendation, please edit that text for tone; it veers a bit too far on the casual side in places for a standards track RFC.)

I’m not sure what we should do with this one.  Previously, much of the material in the appendix was in the main body. A decision was made by others to move it and the verbosity of the main text was reduced in the process.  I'm not sure what we would want to move, though the key table might be a target.

> Appendix B:
 
> It really seems like the packet format should go in the main body (if it’s needed in this document at all.)

It was there once and folks wanted it moved to an appendix. And it has since changed.  The format shown in Double is largely sufficient, but missing the EKT Tag.  So, I stole that and added an EKT Tag.  What do you think?
